### PR TITLE
Fix some typos in explainer.md

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -94,14 +94,14 @@ function visibleTimerCallback(element, observer) {
   processChanges(observer.takeRecords());
   if (element.isVisible) {
     delete element.isVisible;
-    logAddImpressionToServer();
+    logImpressionToServer();
     observer.unobserve(element);
   }
 }
 
 function processChanges(changes) {
   changes.forEach(function(changeRecord) {
-    var element = changeRecord.element;
+    var element = changeRecord.target;
     element.isVisible = isVisible(changeRecord.boundingClientRect, changeRecord.intersectionRect);
     if (element.isVisible) {
       // Transitioned from hidden to visible


### PR DESCRIPTION
Hi! I was starting to go through the documentation, and there were two small typos in the example javascript code, one with a slightly incorrect stub function name, and the other with what seems like simply the wrong attribute.