### PR TITLE
Fix links for repo move to WICG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Intersection Observers
 [Explainer Doc](./explainer.md)
 
-[Draft Spec](http://rawgit.com/slightlyoff/IntersectionObserver/master/index.html)
+[Draft Spec](http://rawgit.com/WICG/IntersectionObserver/master/index.html)

--- a/index.bs
+++ b/index.bs
@@ -1,13 +1,13 @@
 <pre class='metadata'>
 Title: Intersection Observer
 Status: ED
-ED: https://github.com/slightlyoff/IntersectionObserver/
+ED: https://github.com/WICG/IntersectionObserver/
 Shortname: intersection-observer
 Level: 1
 Editor: Michael Blain, Google, mpb@google.com
 Abstract: This specification describes  an API that can be used to understand the visibility and position of DOM elements relative to a viewport. The position is delivered asynchronously and is useful for understanding the visibility of elements and implementing pre-loading and deferred loading of DOM content.
 Group: Web Performance Working Group
-Repository: slightlyoff/IntersectionObserver
+Repository: WICG/IntersectionObserver
 </pre>
 
 <pre class="anchors">

--- a/index.html
+++ b/index.html
@@ -1358,9 +1358,9 @@
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://github.com/slightlyoff/IntersectionObserver/">https://github.com/slightlyoff/IntersectionObserver/</a>
+     <dd><a class="u-url" href="https://github.com/WICG/IntersectionObserver/">https://github.com/WICG/IntersectionObserver/</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/slightlyoff/IntersectionObserver/issues/">GitHub</a>
+     <dd><a href="https://github.com/WICG/IntersectionObserver/issues/">GitHub</a>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mpb@google.com">Michael Blain</a> (<span class="p-org org">Google</span>)
     </dl>


### PR DESCRIPTION
Just found this confusing when reading this spec.