### PR TITLE
Add intersectionRatio attribute to IntersectionObserverEntry.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -117,8 +117,9 @@ it allows applications to significantly reduce their CPU, GPU and energy costs.
 		for (var i in changes) {
 			console.log(changes[i].time);               // Timestamp when the change occurred
 			console.log(changes[i].rootBounds);         // Unclipped area of root
-			console.log(changes[i].intersectionRect);   // Unclipped area of target intersected with rootBounds
 			console.log(changes[i].boundingClientRect); // target.boundingClientRect()
+			console.log(changes[i].intersectionRect);   // boundingClientRect, clipped by its containing block ancestors, and intersected with rootBounds
+			console.log(changes[i].intersectionRatio);  // Ratio of intersectionRect area to boundingClientRect area
 			console.log(changes[i].target);             // the Element target
 		}
 	}, {});
@@ -225,13 +226,14 @@ interface IntersectionObserver {
 		3. Let |intersectionObserverRegistration| be
 			an {{IntersectionObserverRegistration}} record
 			with an {{IntersectionObserverRegistration/observer}} property set to |this|
-			and a {{previousVisibleRatio}} property set to <code>0</code>.
+			and a {{IntersectionObserverRegistration/previousThreshold}} property set to <code>0</code>.
 		4. Append |intersectionObserverRegistration|
 			to |target|'s internal {{[[RegisteredIntersectionObservers]]}} slot.
 		5. Add |target| to |this|'s internal {{[[ObservationTargets]]}} slot.
 	: <dfn>unobserve(target)</dfn>
 	::
-		1. Remove the element whose {{IntersectionObserverRegistration/observer}} property is equal to |this|
+		1. Remove the {{IntersectionObserverRegistration}} record
+			whose {{IntersectionObserverRegistration/observer}} property is equal to |this|
 			from |target|'s internal {{[[RegisteredIntersectionObservers]]}} slot.
 		2. Remove |target| from |this|'s internal {{[[ObservationTargets]]}} slot.
 
@@ -246,7 +248,8 @@ interface IntersectionObserver {
 	::
 		For each |target| in |this|'s internal {{[[ObservationTargets]]}} slot:
 
-		1. Remove the element whose {{IntersectionObserverRegistration/observer}} property is equal to |this|
+		1. Remove the {{IntersectionObserverRegistration}} record
+			whose {{IntersectionObserverRegistration/observer}} property is equal to |this|
 			from |target|'s internal {{[[RegisteredIntersectionObservers]]}} slot.
 		2. Remove |target| from |this|'s internal {{[[ObservationTargets]]}} slot.
 	: <dfn>takeRecords()</dfn>
@@ -358,6 +361,7 @@ interface IntersectionObserverEntry {
 	readonly attribute DOMRectReadOnly rootBounds;
 	readonly attribute DOMRectReadOnly boundingClientRect;
 	readonly attribute DOMRectReadOnly intersectionRect;
+	readonly attribute double intersectionRatio;
 	readonly attribute Element target;
 };
 
@@ -385,6 +389,10 @@ dictionary IntersectionObserverEntryInit {
 		This value represents the portion of
 		{{IntersectionObserverEntry/target}} actually visible
 		within {{IntersectionObserverEntry/rootBounds}}.
+	: <dfn>intersectionRatio</dfn>
+	::
+		Ratio of {{IntersectionObserverEntry/intersectionRect}} area to
+		{{IntersectionObserverEntry/boundingClientRect}} area.
 	: <dfn>rootBounds</dfn>
 	::
 		On getting,
@@ -473,9 +481,9 @@ Element</h4>
 which is initialized to an empty list.
 This list holds <dfn interface>IntersectionObserverRegistration</dfn> records,
 which have an <dfn attribute for=IntersectionObserverRegistration>observer</dfn> property
-holding an {{Element}}
-and a <dfn attribute for=IntersectionObserverRegistration>previousVisibleRatio</dfn> property
-holding a number between 0 and 1.
+holding an {{IntersectionObserver}}
+and a <dfn attribute for=IntersectionObserverRegistration>previousThreshold</dfn> property
+holding a number between 0 and the length of the observer's {{IntersectionObserver/thresholds}} property (inclusive).
 
 <h4 id='intersection-observer-private-slots'>
 IntersectionObserver</h4>
@@ -553,37 +561,35 @@ To <dfn>run the update intersection observations steps</dfn> for an
 2. For each |observer| in |unit|'s <a>IntersectionObservers</a> list:
 	1. Let |rootBounds| be |observer|'s <a>root intersection rectangle</a>.
 	2. For each |target| in |observer|'s internal {{[[ObservationTargets]]}} slot:
-		1. Let |boundingClientRect| be a {{DOMRectReadOnly}}
+		1. Let |targetRect| be a {{DOMRectReadOnly}}
 			obtained by the same algorithm as that of {{Element}}'s
 			{{Element/getBoundingClientRect()}} performed on
 			|target|.
 		2. Let |intersectionRect| be the intersection of
-			|boundingClientRect| with |rootBounds|, intersected with
+			|targetRect| with |rootBounds|, intersected with
 			the clip rect of each ancestor between |target| and
 			the <a>intersection root</a>.
-		3. Let |area| be |boundingClientRect|'s area.
-		4. Let |visibleArea| be |intersectionRect|'s area.
-		5. Let |visibleRatio| be |visibleArea| divided by |area| if |area| is non-zero,
+		3. Let |targetArea| be |targetRect|'s area.
+		4. Let |intersectionArea| be |intersectionRect|'s area.
+		5. Let |intersectionRatio| be |intersectionArea| divided by |targetArea| if |targetArea| is non-zero,
 			and <code>0</code> otherwise.
-		6. Let |threshold| be the index of the first entry in |observer|.{{thresholds}}
-			whose value is greater than or equal to |visibleRatio|.
-			If |visibleRatio| is equal to <code>0</code>,
-			let |threshold| be <code>-1</code>.
-		7. Let |intersectionObserverRegistration| be the element
+		6. If |intersectionRatio| is equal to <code>0</code>,
+			let |threshold| be <code>0</code>.
+			If |intersectionRatio| is equal to <code>1</code>,
+			let |threshold| be the length of |observer|.{{thresholds}}.
+			Otherwise, let |threshold| be the index of the first entry in |observer|.{{thresholds}}
+			whose value is greater than |intersectionRatio|.
+		7. Let |intersectionObserverRegistration| be the {{IntersectionObserverRegistration}} record 
 			in |target|'s internal {{[[RegisteredIntersectionObservers]]}} slot
 			whose {{IntersectionObserverRegistration/observer}} property is equal to |observer|.
-		8. Let |oldVisibleRatio| be set to
-			|intersectionObserverRegistration|'s {{previousVisibleRatio}} property.
-		9. Let |oldThreshold| be the index of the first entry in |observer|.{{thresholds}}
-			whose value is greater than or equal to |oldVisibleRatio|.
-			If |oldVisibleRatio| is equal to <code>0</code>,
-			let |oldThreshold| be <code>-1</code>.
-		10. If |threshold| does not equal |oldThreshold|,
+		8. Let |previousThreshold| be set to
+			|intersectionObserverRegistration|'s {{IntersectionObserverRegistration/previousThreshold}} property.
+		9. If |threshold| does not equal |previousThreshold|,
 			<a>queue an IntersectionObserverEntry</a> for |unit|,
 			passing in |observer|, |time|, |rootBounds|,
 			|boundingClientRect|, |intersectionRect| and |target|.
-		11. Assign |visibleRatio| to
-			|intersectionObserverRegistration|'s {{previousVisibleRatio}} property.
+		10. Assign |threshold| to
+			|intersectionObserverRegistration|'s {{IntersectionObserverRegistration/previousThreshold}} property.
 
 <h4 id='removing-steps'>
 Removing Steps</h4>

--- a/index.html
+++ b/index.html
@@ -1294,7 +1294,7 @@
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Intersection Observer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-02-12">12 February 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-02-14">14 February 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1308,7 +1308,7 @@
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 12 February 2016,
+In addition, as of 14 February 2016,
 the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
 Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
@@ -1397,36 +1397,42 @@ and resorting to exotic plugin-based solutions for computing "true" element visi
    <p>These use-cases have several common properties:</p>
    <ol>
     <li data-md="">
-     <p>They can be represented as passive "queries" about the state of individual
-elements with respect to some other element (or the global viewport).</p>
+     <p>They can be represented as passive "queries"
+about the state of individual elements
+with respect to some other element
+(or the global viewport).</p>
     <li data-md="">
-     <p>They do not impose hard latency requirements; that is to say, the
-information can be delivered asynchronously (e.g. from another thread)
+     <p>They do not impose hard latency requirements;
+that is to say, the information can be delivered asynchronously
+(e.g. from another thread)
 without penalty.</p>
     <li data-md="">
-     <p>They are poorly supported by nearly all combinations of existing web platform
-features, requiring extraordinary developer effort despite their
-widespread use.</p>
+     <p>They are poorly supported by nearly all combinations of existing web platform features,
+requiring extraordinary developer effort despite their widespread use.</p>
    </ol>
-   <p>A notable non-goal is pixel-accurate information about what was actually
-displayed (which can be quite difficult to obtain efficiently in certain
-browser architectures in the face of filters, webgl, and other features). In all
-of these scenarios the information is useful even when delivered at a slight
-delay and without perfect compositing-result data.</p>
-   <p>The Intersersection Observer API addresses the above issues by giving developers
-a new method to asynchronously query the position of an element with respect to
-other elements or the global viewport. The asynchronous delivery eliminates the
-need for costly DOM and style queries, continuous polling, and use of custom
-plugins. By removing the need for these methods it allows applications to
-significantly reduce their CPU, GPU and energy costs.</p>
-   <div class="example" id="example-25a3b0b0">
-    <a class="self-link" href="#example-25a3b0b0"></a> 
+   <p>A notable non-goal is pixel-accurate information about what was actually displayed
+(which can be quite difficult to obtain efficiently in certain browser architectures
+in the face of filters, webgl, and other features).
+In all of these scenarios the information is useful
+even when delivered at a slight delay
+and without perfect compositing-result data.</p>
+   <p>The Intersersection Observer API addresses the above issues
+by giving developers a new method to asynchronously query the position of an element
+with respect to other elements or the global viewport.
+The asynchronous delivery eliminates the need for costly DOM and style queries,
+continuous polling,
+and use of custom plugins.
+By removing the need for these methods
+it allows applications to significantly reduce their CPU, GPU and energy costs.</p>
+   <div class="example" id="example-3475dac2">
+    <a class="self-link" href="#example-3475dac2"></a> 
 <pre>var observer = new IntersectionObserver(function(changes) {
   for (var i in changes) {
     console.log(changes[i].time);               // Timestamp when the change occurred
     console.log(changes[i].rootBounds);         // Unclipped area of root
-    console.log(changes[i].intersectionRect);   // Unclipped area of target intersected with rootBounds
     console.log(changes[i].boundingClientRect); // target.boundingClientRect()
+    console.log(changes[i].intersectionRect);   // boundingClientRect, clipped by its containing block ancestors, and intersected with rootBounds
+    console.log(changes[i].intersectionRatio);  // Ratio of intersectionRect area to boundingClientRect area
     console.log(changes[i].target);             // the Element target
   }
 }, {});
@@ -1518,7 +1524,7 @@ return.</p>
        <li data-md="">
         <p>Let <var>intersectionObserverRegistration</var> be
 an <code class="idl"><a data-link-type="idl" href="#intersectionobserverregistration">IntersectionObserverRegistration</a></code> record
-with an <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property set to <var>this</var> and a <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousvisibleratio">previousVisibleRatio</a></code> property set to <code>0</code>.</p>
+with an <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property set to <var>this</var> and a <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousthreshold">previousThreshold</a></code> property set to <code>0</code>.</p>
        <li data-md="">
         <p>Append <var>intersectionObserverRegistration</var> to <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot.</p>
        <li data-md="">
@@ -1529,7 +1535,8 @@ with an <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserve
      <dd data-md="">
       <ol>
        <li data-md="">
-        <p>Remove the element whose <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property is equal to <var>this</var> from <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot.</p>
+        <p>Remove the <code class="idl"><a data-link-type="idl" href="#intersectionobserverregistration">IntersectionObserverRegistration</a></code> record
+whose <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property is equal to <var>this</var> from <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot.</p>
        <li data-md="">
         <p>Remove <var>target</var> from <var>this</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-observationtargets-slot">[[ObservationTargets]]</a></code> slot.</p>
       </ol>
@@ -1546,7 +1553,8 @@ or create a separate <code class="idl"><a data-link-type="idl" href="#intersecti
       <p>For each <var>target</var> in <var>this</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-observationtargets-slot">[[ObservationTargets]]</a></code> slot:</p>
       <ol>
        <li data-md="">
-        <p>Remove the element whose <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property is equal to <var>this</var> from <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot.</p>
+        <p>Remove the <code class="idl"><a data-link-type="idl" href="#intersectionobserverregistration">IntersectionObserverRegistration</a></code> record
+whose <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property is equal to <var>this</var> from <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot.</p>
        <li data-md="">
         <p>Remove <var>target</var> from <var>this</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-observationtargets-slot">[[ObservationTargets]]</a></code> slot.</p>
       </ol>
@@ -1654,6 +1662,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="int
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-rootbounds">rootBounds</a>;
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-boundingclientrect">boundingClientRect</a>;
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-intersectionrect">intersectionRect</a>;
+  readonly attribute double <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="double " href="#dom-intersectionobserverentry-intersectionratio">intersectionRatio</a>;
   readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="Element " href="#dom-intersectionobserverentry-target">target</a>;
 };
 
@@ -1681,6 +1690,10 @@ rects (up to but not including <code class="idl"><a data-link-type="idl" href="#
 intersected with <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverentry-rootbounds">rootBounds</a></code>.
 This value represents the portion of <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverentry-target">target</a></code> actually visible
 within <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverentry-rootbounds">rootBounds</a></code>.</p>
+     <dt data-md="">
+      <p><dfn class="idl-code" data-dfn-for="IntersectionObserverEntry" data-dfn-type="attribute" data-export="" id="dom-intersectionobserverentry-intersectionratio">intersectionRatio<a class="self-link" href="#dom-intersectionobserverentry-intersectionratio"></a></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span></p>
+     <dd data-md="">
+      <p>Ratio of <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverentry-intersectionrect">intersectionRect</a></code> area to <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverentry-boundingclientrect">boundingClientRect</a></code> area.</p>
      <dt data-md="">
       <p><dfn class="idl-code" data-dfn-for="IntersectionObserverEntry" data-dfn-type="attribute" data-export="" id="dom-intersectionobserverentry-rootbounds">rootBounds<a class="self-link" href="#dom-intersectionobserverentry-rootbounds"></a></dfn>, <span> of type <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a>, readonly</span></p>
      <dd data-md="">
@@ -1750,8 +1763,8 @@ is initialized to false and an <dfn data-dfn-for="browsing context" data-dfn-typ
 which is initialized to an empty list.
 This list holds <dfn class="idl-code" data-dfn-type="interface" data-export="" id="intersectionobserverregistration">IntersectionObserverRegistration<a class="self-link" href="#intersectionobserverregistration"></a></dfn> records,
 which have an <dfn class="idl-code" data-dfn-for="IntersectionObserverRegistration" data-dfn-type="attribute" data-export="" id="dom-intersectionobserverregistration-observer">observer<a class="self-link" href="#dom-intersectionobserverregistration-observer"></a></dfn> property
-holding an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> and a <dfn class="idl-code" data-dfn-for="IntersectionObserverRegistration" data-dfn-type="attribute" data-export="" id="dom-intersectionobserverregistration-previousvisibleratio">previousVisibleRatio<a class="self-link" href="#dom-intersectionobserverregistration-previousvisibleratio"></a></dfn> property
-holding a number between 0 and 1.</p>
+holding an <code class="idl"><a data-link-type="idl" href="#intersectionobserver">IntersectionObserver</a></code> and a <dfn class="idl-code" data-dfn-for="IntersectionObserverRegistration" data-dfn-type="attribute" data-export="" id="dom-intersectionobserverregistration-previousthreshold">previousThreshold<a class="self-link" href="#dom-intersectionobserverregistration-previousthreshold"></a></dfn> property
+holding a number between 0 and the length of the observer’s <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-thresholds">thresholds</a></code> property (inclusive).</p>
    <h4 class="heading settled" data-level="3.1.3" id="intersection-observer-private-slots"><span class="secno">3.1.3. </span><span class="content"> IntersectionObserver</span><a class="self-link" href="#intersection-observer-private-slots"></a></h4>
    <p><code class="idl"><a data-link-type="idl" href="#intersectionobserver">IntersectionObserver</a></code> objects have internal <dfn class="idl-code" data-dfn-for="IntersectionObserver" data-dfn-type="attribute" data-export="" id="dom-intersectionobserver-queuedentries-slot">[[QueuedEntries]]<a class="self-link" href="#dom-intersectionobserver-queuedentries-slot"></a></dfn> and <dfn class="idl-code" data-dfn-for="IntersectionObserver" data-dfn-type="attribute" data-export="" id="dom-intersectionobserver-observationtargets-slot">[[ObservationTargets]]<a class="self-link" href="#dom-intersectionobserver-observationtargets-slot"></a></dfn> slots,
 which are initialized to empty lists and an internal <dfn class="idl-code" data-dfn-for="IntersectionObserver" data-dfn-type="attribute" data-export="" id="dom-intersectionobserver-callback-slot">[[callback]]<a class="self-link" href="#dom-intersectionobserver-callback-slot"></a></dfn> slot
@@ -1822,37 +1835,35 @@ run these steps:</p>
        <p>For each <var>target</var> in <var>observer</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-observationtargets-slot">[[ObservationTargets]]</a></code> slot:</p>
        <ol>
         <li data-md="">
-         <p>Let <var>boundingClientRect</var> be a <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a></code> obtained by the same algorithm as that of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">getBoundingClientRect()</a></code> performed on <var>target</var>.</p>
+         <p>Let <var>targetRect</var> be a <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a></code> obtained by the same algorithm as that of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>'s <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">getBoundingClientRect()</a></code> performed on <var>target</var>.</p>
         <li data-md="">
-         <p>Let <var>intersectionRect</var> be the intersection of <var>boundingClientRect</var> with <var>rootBounds</var>, intersected with
+         <p>Let <var>intersectionRect</var> be the intersection of <var>targetRect</var> with <var>rootBounds</var>, intersected with
 the clip rect of each ancestor between <var>target</var> and
 the <a data-link-type="dfn" href="#intersectionobserver-intersection-root">intersection root</a>.</p>
         <li data-md="">
-         <p>Let <var>area</var> be <var>boundingClientRect</var>’s area.</p>
+         <p>Let <var>targetArea</var> be <var>targetRect</var>’s area.</p>
         <li data-md="">
-         <p>Let <var>visibleArea</var> be <var>intersectionRect</var>’s area.</p>
+         <p>Let <var>intersectionArea</var> be <var>intersectionRect</var>’s area.</p>
         <li data-md="">
-         <p>Let <var>visibleRatio</var> be <var>visibleArea</var> divided by <var>area</var> if <var>area</var> is non-zero,
+         <p>Let <var>intersectionRatio</var> be <var>intersectionArea</var> divided by <var>targetArea</var> if <var>targetArea</var> is non-zero,
 and <code>0</code> otherwise.</p>
         <li data-md="">
-         <p>Let <var>threshold</var> be the index of the first entry in <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-thresholds">thresholds</a></code> whose value is greater than or equal to <var>visibleRatio</var>.
-If <var>visibleRatio</var> is equal to <code>0</code>,
-let <var>threshold</var> be <code>-1</code>.</p>
+         <p>If <var>intersectionRatio</var> is equal to <code>0</code>,
+let <var>threshold</var> be <code>0</code>.
+If <var>intersectionRatio</var> is equal to <code>1</code>,
+let <var>threshold</var> be the length of <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-thresholds">thresholds</a></code>.
+Otherwise, let <var>threshold</var> be the index of the first entry in <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-thresholds">thresholds</a></code> whose value is greater than <var>intersectionRatio</var>.</p>
         <li data-md="">
-         <p>Let <var>intersectionObserverRegistration</var> be the element
+         <p>Let <var>intersectionObserverRegistration</var> be the <code class="idl"><a data-link-type="idl" href="#intersectionobserverregistration">IntersectionObserverRegistration</a></code> record
 in <var>target</var>’s internal <code class="idl"><a data-link-type="idl" href="#dom-element-registeredintersectionobservers-slot">[[RegisteredIntersectionObservers]]</a></code> slot
 whose <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-observer">observer</a></code> property is equal to <var>observer</var>.</p>
         <li data-md="">
-         <p>Let <var>oldVisibleRatio</var> be set to <var>intersectionObserverRegistration</var>’s <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousvisibleratio">previousVisibleRatio</a></code> property.</p>
+         <p>Let <var>previousThreshold</var> be set to <var>intersectionObserverRegistration</var>’s <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousthreshold">previousThreshold</a></code> property.</p>
         <li data-md="">
-         <p>Let <var>oldThreshold</var> be the index of the first entry in <var>observer</var>.<code class="idl"><a data-link-type="idl" href="#dom-intersectionobserver-thresholds">thresholds</a></code> whose value is greater than or equal to <var>oldVisibleRatio</var>.
-If <var>oldVisibleRatio</var> is equal to <code>0</code>,
-let <var>oldThreshold</var> be <code>-1</code>.</p>
-        <li data-md="">
-         <p>If <var>threshold</var> does not equal <var>oldThreshold</var>, <a data-link-type="dfn" href="#queue-an-intersectionobserverentry">queue an IntersectionObserverEntry</a> for <var>unit</var>,
+         <p>If <var>threshold</var> does not equal <var>previousThreshold</var>, <a data-link-type="dfn" href="#queue-an-intersectionobserverentry">queue an IntersectionObserverEntry</a> for <var>unit</var>,
 passing in <var>observer</var>, <var>time</var>, <var>rootBounds</var>, <var>boundingClientRect</var>, <var>intersectionRect</var> and <var>target</var>.</p>
         <li data-md="">
-         <p>Assign <var>visibleRatio</var> to <var>intersectionObserverRegistration</var>’s <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousvisibleratio">previousVisibleRatio</a></code> property.</p>
+         <p>Assign <var>threshold</var> to <var>intersectionObserverRegistration</var>’s <code class="idl"><a data-link-type="idl" href="#dom-intersectionobserverregistration-previousthreshold">previousThreshold</a></code> property.</p>
        </ol>
      </ol>
    </ol>
@@ -1923,6 +1934,7 @@ in the HTML Processing Model.</p>
    <li><a href="#intersectionobserverregistration">IntersectionObserverRegistration</a><span>, in §3.1.2</span>
    <li><a href="#browsing-context-intersectionobservers">IntersectionObservers</a><span>, in §3.1.1</span>
    <li><a href="#browsing-context-intersectionobservertaskqueued">IntersectionObserverTaskQueued</a><span>, in §3.1.1</span>
+   <li><a href="#dom-intersectionobserverentry-intersectionratio">intersectionRatio</a><span>, in §2.3</span>
    <li>
     intersectionRect
     <ul>
@@ -1935,7 +1947,7 @@ in the HTML Processing Model.</p>
    <li><a href="#dom-intersectionobserverregistration-observer">observer</a><span>, in §3.1.2</span>
    <li><a href="#dom-intersectionobserver-observe">observe(target)</a><span>, in §2.2</span>
    <li><a href="#parse-a-root-margin">parse a root margin</a><span>, in §2.2</span>
-   <li><a href="#dom-intersectionobserverregistration-previousvisibleratio">previousVisibleRatio</a><span>, in §3.1.2</span>
+   <li><a href="#dom-intersectionobserverregistration-previousthreshold">previousThreshold</a><span>, in §3.1.2</span>
    <li><a href="#intersection-observer-processing-model">Processing Model</a><span>, in §2.4</span>
    <li><a href="#queue-an-intersectionobserverentry">queue an IntersectionObserverEntry</a><span>, in §3.2.3</span>
    <li><a href="#queue-an-intersection-observer-task">queue an intersection observer task</a><span>, in §3.2.1</span>
@@ -2069,6 +2081,7 @@ interface <a href="#intersectionobserverentry">IntersectionObserverEntry</a> {
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-rootbounds">rootBounds</a>;
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-boundingclientrect">boundingClientRect</a>;
   readonly attribute <a data-link-type="idl-name" href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">DOMRectReadOnly</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMRectReadOnly " href="#dom-intersectionobserverentry-intersectionrect">intersectionRect</a>;
+  readonly attribute double <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="double " href="#dom-intersectionobserverentry-intersectionratio">intersectionRatio</a>;
   readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="Element " href="#dom-intersectionobserverentry-target">target</a>;
 };
 


### PR DESCRIPTION
Also, converge terminology around intersectionRatio and
intersectionRect, rather that visibleRatio/visibleRect.

Also, IntersectionObserverRegistration stores previousThreshold
rather than previousVisibleRatio.

Issue #96 