### PR TITLE
Don't specify behavior of observer with invalid root.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -45,7 +45,6 @@ urlPrefix: https://heycam.github.io/webidl/
 	urlPrefix: #dfn-; type:dfn; text: throw
 	urlPrefix: #idl-; type:interface; text: double
 	url: #hierarchyrequesterror; type: exception; text: HierarchyRequestError
-	url: #invalidstateerror; type: exception; text: InvalidStateError
 urlPrefix: https://drafts.csswg.org/css-box/
 	url: #viewport; type: dfn; text: viewport
 	url: #containing-block; type: dfn; text: containing block
@@ -637,10 +636,6 @@ An {{IntersectionObserver}} will continue observing a target until any of the fo
 	<li>The target {{Element}} is deleted.</li>
 	<li>The observer's <a>intersection root</a> is deleted.
 </ul>
-
-If an {{IntersectionObserver}}'s <a>intersection root</a> is deleted
-while there are still JavaScript references to the observer,
-calling any API method on the observer will <a>throw</a> an {{InvalidStateError}}.
 
 <h3 id='external-spec-integrations'>
 External Spec Integrations</h3>

--- a/index.html
+++ b/index.html
@@ -1923,9 +1923,6 @@ passing in <var>observer</var>, <var>time</var>, <var>rootBounds</var>, <var>bou
     <li>The target <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code> is deleted.
     <li>The observer’s <a data-link-type="dfn" href="#intersectionobserver-intersection-root">intersection root</a> is deleted. 
    </ul>
-   <p>If an <code class="idl"><a data-link-type="idl" href="#intersectionobserver">IntersectionObserver</a></code>'s <a data-link-type="dfn" href="#intersectionobserver-intersection-root">intersection root</a> is deleted
-while there are still JavaScript references to the observer,
-calling any API method on the observer will <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code>.</p>
    <h3 class="heading settled" data-level="3.4" id="external-spec-integrations"><span class="secno">3.4. </span><span class="content"> External Spec Integrations</span><a class="self-link" href="#external-spec-integrations"></a></h3>
    <h4 class="heading settled" data-level="3.4.1" id="event-loop"><span class="secno">3.4.1. </span><span class="content"> HTML Processing Model: Event Loop</span><a class="self-link" href="#event-loop"></a></h4>
    <p>An <a data-link-type="dfn" href="#intersection-observer">Intersection Observer</a> processing step should take place


### PR DESCRIPTION
The concept of a node being "deleted", as opposed to merely being
detached from the DOM, is not specified by any standard, so we
shouldn't refer to it here.