### PR TITLE
Add IntersectionObserver polyfill

### DIFF
--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -112,7 +112,7 @@ limitations under the License.
     _update: function() {
       var rootRect = this._rootRect();
       this._observationTargets.forEach(function(oldIntersectionEntry, target) {
-        var targetRect = target.getBoundingClientRect();
+        var targetRect = augmentRect(target.getBoundingClientRect());
         var intersectionRect = intersectRects(rootRect, targetRect);
         if(!intersectionRect) {
           return;
@@ -159,7 +159,7 @@ limitations under the License.
 
     _rootRect: function() {
       if(this._root) {
-        return this.root.getBoundingClientRect();
+        return augmentRect(this.root.getBoundingClientRect());
       }
       return {
         top: 0,
@@ -221,5 +221,11 @@ limitations under the License.
         fn.apply(context, args);
       }, delay);
     };
+  };
+
+  var augmentRect = function(r) {
+    r.width = r.width || r.right - r.left;
+    r.height = r.height || r.bottom - r.top;
+    return r;
   };
 })();

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -1,0 +1,188 @@
+(function() {
+  // TODO: rootMargin are completely ignored for now
+  
+  // Constructor
+  window.IntersectionObserver = function(callback, options) {
+    options = options || {};
+    
+    if(!(callback instanceof Function)) {
+      throw('callback needs to be a function');
+    }
+    
+    this._callback = callback;
+    this._root = options.root || null;
+    this._rootMargin = options.rootMargin || [0, 0, 0, 0];
+    this._thresholds = options.threshold || 0;
+    this._init();
+  };
+
+  window.IntersectionObserver.prototype = {
+    //
+    // Public API
+    //
+    get root() {
+      return this._root || document;
+    },
+    
+    get rootMargin() {
+      return '0';
+    },
+    
+    get thresholds() {
+      // 0 means call callback on every change
+      // See note at http://rawgit.com/WICG/IntersectionObserver/master/index.html#intersection-observer-init
+      if(this._thresholds === 0) {
+        return 0;
+      }
+      if(this._thresholds instanceof Array) {
+        return this._thresholds;
+      }
+      return [this._thresholds];
+    },
+    
+    observe: function(target) {
+      if(!(target instanceof HTMLElement)) {
+        throw('Target needs to be an HTMLelement');
+      }
+      
+      var root = this.root;
+      var ancestor = target.parentNode;
+      while (ancestor != root) {
+        if (!ancestor) {
+          throw('Target must be decendant of root');
+        }
+        ancestor = ancestor.parentNode;   
+      }
+      
+      this._observationTargets.set(target, {});
+    },
+    
+    unobserve: function(target) {
+      this._observationTargets.delete(target);
+    },
+    
+    disconnect: function() {
+      this._observationTargets.clear();
+      this.root.removeEventListener('scroll', this._boundUpdate);
+      window.clearInterval(this._timeoutId);
+      this._descheduleCallback();
+    },
+    
+    takeRecords: function() {
+      this._update();
+      this._descheduleCallback();
+      var copy = this._queue.slice();
+      this._queue = [];
+      return copy;
+    },
+    
+    //
+    // Private API
+    //
+    _init: function() {
+      this._observationTargets = new Map();
+      this._boundUpdate = this._update.bind(this);
+      this.root.addEventListener('scroll', this._boundUpdate);
+      this._intervalId = window.setInterval(this._boundUpdate, 100);
+      this._queue = [];
+    },
+    
+    _update: function() {
+      var rootRect = this._rootRect();
+      this._observationTargets.forEach(function(oldIntersectionEntry, target) {
+        var targetRect = target.getBoundingClientRect();
+        var intersectionRect = intersectRects(rootRect, targetRect);
+        if(!intersectionRect) {
+          return;
+        }
+        var targetArea = targetRect.width * targetRect.height;
+        var intersectionArea = intersectionRect.width * intersectionRect.height;
+        var intersectionRatio = intersectionArea / targetArea;
+        if(!this._hasCrossedThreshold(oldIntersectionEntry.intersectionRatio, intersectionRatio)) {
+          return;
+        }
+        var intersectionEntry = {
+          time: window.performance.now(),
+          rootBounds: rootRect,
+          boundingClientRect: targetRect,
+          intersectionRect: intersectionRect,
+          intersectionRatio: intersectionRatio,
+          target: target
+        };
+        Object.freeze(intersectionEntry);
+        this._queue.push(intersectionEntry);
+        this._scheduleCallback();
+        this._observationTargets.set(target, intersectionEntry);
+      }.bind(this));
+    },
+    
+    _scheduleCallback: function() {
+      if(this._idleCallbackId) {
+        return;
+      }
+      this._idleCallbackId = window.requestIdleCallback(function() {
+        this._descheduleCallback();
+        this._callback(this._queue, this);
+        this._queue = [];
+      }.bind(this), {timeout: 100});
+    },
+    
+    _descheduleCallback: function() {
+      if(!this._idleCallbackId) {
+        return;
+      }
+      window.cancelIdleCallback(this._idleCallbackId);
+      this._idleCallbackId = null;
+    },
+    
+    _rootRect: function() {
+      if(this._root) {
+        return this.root.getBoundingClientRect();
+      }
+      return {
+        top: 0,
+        left: 0,
+        right: window.innerWidth,
+        width: window.innerWidth,
+        bottom: window.innerHeight,
+        height: window.innerHeight
+      };
+    },
+    
+    // FIXME: so hack, much performance, very JSON
+    _hasCrossedThreshold: function(oldRatio, newRatio) {
+      if(this.thresholds === 0) {
+        return newRatio != oldRatio;
+      }
+      var b1 = this.thresholds.map(function(threshold) {
+        return threshold <= oldRatio;
+      });
+      var b2 = this.thresholds.map(function(threshold) {
+        return threshold <= newRatio;
+      });
+      return JSON.stringify(b1) !== JSON.stringify(b2);
+    }
+  };
+
+  var intersectRects = function(rect1, rect2) {
+    var top = Math.max(rect1.top, rect2.top);
+    var bottom = Math.min(rect1.bottom, rect2.bottom);
+    var left = Math.max(rect1.left, rect2.left);
+    var right = Math.min(rect1.right, rect2.right);
+    var intersectionRect = {
+      top: top,
+      bottom: bottom,
+      left: left,
+      right: right,
+      width: right-left,
+      height: bottom-top
+    };
+    if(top > bottom) {
+      intersectionRect.height = 0;
+    }
+    if(left > right) {
+      intersectionRect.width = 0;
+    }
+    return intersectionRect;
+  };
+})();

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -53,7 +53,7 @@
       var ancestor = target.parentNode;
       while (ancestor != root) {
         if (!ancestor) {
-          throw('Target must be decendant of root');
+          throw('Target must be descendant of root');
         }
         ancestor = ancestor.parentNode;
       }

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -1,3 +1,15 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 (function() {
   // TODO: rootMargin are completely ignored for now
 
@@ -197,17 +209,17 @@
   };
 
   var debounce = function(fn, delay) {
-  var timer = null;
-  return function () {
-    if(timer) {
-      return;
-    }
-    var context = this, args = arguments;
-    clearTimeout(timer);
-    timer = setTimeout(function () {
-      timer = null;
-      fn.apply(context, args);
-    }, delay);
+    var timer = null;
+    return function () {
+      if(timer) {
+        return;
+      }
+      var context = this, args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        timer = null;
+        fn.apply(context, args);
+      }, delay);
+    };
   };
-}
 })();

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -86,7 +86,7 @@
     _init: function() {
       this._observationTargets = new Map();
       this._boundUpdate = this._update.bind(this);
-      this.root.addEventListener('scroll', this._boundUpdate);
+      this.root.addEventListener('scroll', debounce(this._boundUpdate, 100));
       this._intervalId = window.setInterval(this._boundUpdate, 100);
       this._queue = [];
     },
@@ -189,4 +189,19 @@
     }
     return intersectionRect;
   };
+
+  var debounce = function(fn, delay) {
+  var timer = null;
+  return function () {
+    if(timer) {
+      return;
+    }
+    var context = this, args = arguments;
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      timer = null;
+      fn.apply(context, args);
+    }, delay);
+  };
+}
 })();

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -59,6 +59,9 @@ limitations under the License.
     },
 
     observe: function(target) {
+      if(this._observationTargets.has(target)) {
+        return;
+      }
       if(!(target instanceof HTMLElement)) {
         throw('Target needs to be an HTMLelement');
       }
@@ -68,7 +71,6 @@ limitations under the License.
       if(!root.contains(target)) {
         throw('Target must be descendant of root');
       }
-
       this._mutationObserver.observe(target, {
         attributes: true,
         childList: true,
@@ -76,6 +78,7 @@ limitations under the License.
         subtree: true
       });
       this._observationTargets.set(target, {});
+      this._update();
     },
 
     unobserve: function(target) {
@@ -105,6 +108,12 @@ limitations under the License.
       this._boundUpdate = throttle(this._update.bind(this), POLL_INTERVAL);
       this.root.addEventListener('scroll', this._boundUpdate);
       this._mutationObserver = new MutationObserver(this._boundUpdate);
+      this._mutationObserver.observe(this.root, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true
+      });
       this._queue = [];
     },
 
@@ -207,7 +216,7 @@ limitations under the License.
     return intersectionRect;
   };
 
-  scope.IntersectionObserver = IntersectionObserver;
+  scope.IntersectionObserver = scope.IntersectionObserver || IntersectionObserver;
 
   var throttle = function(fn, int) {
     var timer = null;
@@ -215,10 +224,10 @@ limitations under the License.
       if (timer) {
         return;
       }
-      fn.apply(this, arguments);
       timer = setTimeout(function () {
+        fn.apply(this, arguments);
         timer = null;
-      }, int);
+      }.bind(this), int);
     };
   };
 

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -215,7 +215,7 @@ limitations under the License.
       if (timer) {
         return;
       }
-      callback.apply(this, arguments);
+      fn.apply(this, arguments);
       timer = setTimeout(function () {
         timer = null;
       }, int);

--- a/polyfill/intersectionobserver-polyfill.js
+++ b/polyfill/intersectionobserver-polyfill.js
@@ -58,6 +58,12 @@
         ancestor = ancestor.parentNode;
       }
 
+      this._mutationObserver.observe(target, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true
+      });
       this._observationTargets.set(target, {});
     },
 
@@ -68,7 +74,7 @@
     disconnect: function() {
       this._observationTargets.clear();
       this.root.removeEventListener('scroll', this._boundUpdate);
-      window.clearInterval(this._timeoutId);
+      this._mutationObserver.disconnect();
       this._descheduleCallback();
     },
 
@@ -87,7 +93,7 @@
       this._observationTargets = new Map();
       this._boundUpdate = this._update.bind(this);
       this.root.addEventListener('scroll', debounce(this._boundUpdate, 100));
-      this._intervalId = window.setInterval(this._boundUpdate, 100);
+      this._mutationObserver = new MutationObserver(debounce(this._boundUpdate, 100));
       this._queue = [];
     },
 

--- a/polyfill/intersectionobserver_test.html
+++ b/polyfill/intersectionobserver_test.html
@@ -1,315 +1,246 @@
 <!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <style>
+    root {
+    background-color: pink;
+    display: block;
+    }
+    child {
+    background-color: salmon;
+    display: block;
+    }
+    </style>
+</head>
+<body>
 <script src="intersectionobserver-polyfill.js"></script>
-<style>
-root {
-  background-color: pink;
-  display: block;
-}
-child {
-  background-color: salmon;
-  display: block;
-}
-</style>
 <div id="container" style="position: relative"></div>
 <div id="logger" style="white-space: pre-wrap"></div>
-<script>
-var testIndex = 0;
-
-function test(callback, title) {
-  if(!title) {
-    title = '';
-  }
-  document.getElementById('container').innerHTML = '';
-  document.getElementById('logger').innerHTML += 'Test ' + title + ' ' + (++testIndex) + ': ' + callback() + '\n\n';
-}
-
-function assert(a) {
-  if (a) {
-    return 'Passed';
-  }
-  return '<b>Failed</b>';
-}
-
-test(()=>{
-  return assert(true);
-}, 'the testing framework')
-
-// Observing root not in the DOM.
-test(()=>{
-  var root = document.createElement('div');
-  var io = new IntersectionObserver(function(){},{
-    root: root,
-  });
-
-  var didThrow = false;
-  try {
-    io.observe(document.getElementById('container'));
-  } catch (e) {
-    didThrow = true;
-  }
-
-  io.disconnect();
-  return assert(didThrow);
-}, 'Observing root not in the DOM')
-
-// Observing unrooted element.
-test(()=>{
-  var io = new IntersectionObserver(function(){}, {});
-
-  var didThrow = false;
-  try {
-    io.observe(document.createElement('container'));
-  } catch (e) {
-    didThrow = true;
-  }
-
-  io.disconnect();
-  return assert(didThrow);
-}, 'Observing unrooted element')
-
-// Observing child of root.
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      root: root
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  var didThrow = false;
-  try {
-    io.observe(child);
-  } catch (e) {
-    didThrow = true;
-  }
-
-  io.disconnect();
-  return assert(!didThrow);
-}, 'Observing child of root')
-
-// takeRecords and observe already intersecting element.
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  root.style.height = "100px";
-  root.style.width = "100px";
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      root: root
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  child.style.height = "20px";
-  child.style.width = "20px";
-  child.style.position = "absolute";
-
-  io.observe(child);
-
-  var numRecords = io.takeRecords().length;
-  io.disconnect();
-  return assert(numRecords);
-}, 'takeRecords and observe already intersecting element')
-
-// Observe non-intersecting element.
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  root.style.height = "100px";
-  root.style.width = "100px";
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      root: root,
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  child.style.height = "20px";
-  child.style.width = "20px";
-  child.style.position = "absolute";
-  child.style.top = "-20px";
-
-  io.observe(child);
-
-  var records = io.takeRecords();
-  io.disconnect();
-  return assert(records.length === 1 && records[0].intersectionRatio === 0);
-}, 'observe non-intersecting element')
-
-// thresholds
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  root.style.height = "100px";
-  root.style.width = "100px";
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      threshold: 0.5,
-      root: root,
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  child.style.height = "20px";
-  child.style.width = "20px";
-  child.style.position = "absolute";
-
-  io.observe(child);
-
-  var output = []
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio === 1));
-
-  child.style.top = "-11px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.5));
-
-  child.style.top = "-10px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio === 0.5));
-
-  io.disconnect();
-  return output.join('\n');
-}, 'thresholds')
-
-// multiple thresholds
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  root.style.height = "100px";
-  root.style.width = "100px";
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      threshold: [0.5, 0.25],
-      root: root,
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  child.style.height = "20px";
-  child.style.width = "20px";
-  child.style.position = "absolute";
-
-  io.observe(child);
-
-  var output = []
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio === 1));
-
-  child.style.top = "-11px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.5 && records[0].intersectionRatio >= 0.25));
-
-  child.style.top = "-16px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.25));
-
-  child.style.top = "-17px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 0));
-
-  child.style.top = "-15px";
-  var records = io.takeRecords();
-  output.push(assert(records.length == 1 && records[0].intersectionRatio === 0.25));
-
-  io.disconnect();
-  return output.join('\n');
-}, 'multiple thresholds')
-
-// margins
-test(()=>{
-  var container = document.getElementById('container');
-  var root = document.createElement('root');
-  container.appendChild(root);
-
-  root.style.height = "100px";
-  root.style.width = "200px";
-
-  var io = new IntersectionObserver(
-    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
-    {
-      margin: "5px 10% 10% 15px",
-      root: root,
-    }
-  );
-
-  var child = document.createElement('child');
-  root.appendChild(child);
-
-  child.style.height = "20px";
-  child.style.width = "20px";
-  child.style.position = "absolute";
-
-  io.observe(child);
-
-  var output = []
-  output.push(assert(io.takeRecords().length));
-
-  // Stop intersecting from the top.
-  child.style.top = "-25px";
-  output.push(assert(io.takeRecords().length));
-
-  // Start intersecting from the top.
-  child.style.top = "-24px";
-  output.push(assert(io.takeRecords().length));
-
-  // Stop intersecting from the bottom.
-  child.style.top = "110px";
-  output.push(assert(io.takeRecords().length));
-
-  // Start intersecting from the bottom.
-  child.style.top = "109px";
-  output.push(assert(io.takeRecords().length));
-
-  // Stop intersecting from the left.
-  child.style.left = "-35px";
-  output.push(assert(io.takeRecords().length));
-
-  // Start intersecting from the left.
-  child.style.left = "-34px";
-  output.push(assert(io.takeRecords().length));
-
-  // Stop intersecting from the right.
-  child.style.left = "220px";
-  output.push(assert(io.takeRecords().length));
-
-  // Start intersecting from the right.
-  child.style.left = "219px";
-  output.push(assert(io.takeRecords().length));
-
-  io.disconnect();
-  return output.join('\n');
-}, 'margins')
-
-</script>
+    <div id="mocha"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/2.4.5/mocha.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.min.js"></script>
+    <script>mocha.setup('bdd')</script>
+    <script>
+        function promiseAnimationFrame() {
+            return new Promise(function(resolve) {
+                requestAnimationFrame(function() {
+                   resolve();
+                });
+            });
+        }
+
+        function await(f, timeout) {
+          var stack = new Error().stack;
+          return function() {
+            return new Promise(function(resolve) {
+              var timeoutId = setTimeout(function() {
+                throw new Error("Timed out " + stack);
+              }, timeout);
+              intervalId = setInterval(function() {
+                if(f()) {
+                  clearInterval(intervalId);
+                  clearTimeout(timeoutId);
+                  resolve();
+                }
+              }, 50);
+            });
+          };
+        }
+
+        var rootEl, childEl, io;
+
+        beforeEach(function() {
+            io = null;
+            rootEl = document.createElement('div');
+            rootEl.setAttribute('style', 'display:block; position: relative; width: 200px; height: 100px; overflow: auto; background: #bbb');
+            childEl = document.createElement('div');
+            childEl.setAttribute('style', 'display:block; position: absolute; width: 20px; height: 20px; background: #f00');
+        });
+
+        afterEach(function() {
+            if (io && 'disconnect' in io) io.disconnect();
+            if (childEl.parentNode) childEl.parentNode.removeChild(childEl);
+            if (rootEl.parentNode) rootEl.parentNode.removeChild(rootEl);
+        });
+
+        it("triggers if elements already intersect when observing begins", function(done) {
+            rootEl.appendChild(childEl);
+            document.body.appendChild(rootEl);
+
+            io = new IntersectionObserver(
+                function(records) {
+                    expect(records.length).to.be(1);
+                    // expect(records[0].intersectionRatio).to.be(1);
+                    done();
+                },
+                {root: rootEl}
+            );
+
+            io.observe(childEl);
+        });
+
+        it("reports at threshold correctly", function(done) {
+            rootEl.appendChild(childEl);
+            document.body.appendChild(rootEl);
+
+            var callCounter = 0;
+            io = new IntersectionObserver(
+                function(records) {
+                    switch(callCounter) {
+                    case 0:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be(1);
+                    break;
+                    case 1:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
+                    break;
+                    case 2:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be(0.5);
+                    break;
+                    default:
+                      throw new Error("Too many calls");
+                    }
+                    callCounter++;
+                },
+                {root: rootEl, threshold: 0.5}
+            );
+
+            io.observe(childEl);
+
+            promiseAnimationFrame()
+            .then(await(function(){return callCounter == 1;}, 500))
+            .then(function() {
+                childEl.style.top = "-11px";
+            })
+            .then(await(function(){return callCounter == 2;}, 500))
+            .then(function() {
+                childEl.style.top = "-16px";
+            })
+            .then(promiseAnimationFrame)
+            .then(function() {
+                expect(io.takeRecords().length).to.be(0);
+                expect(callCounter).to.be(2);
+                childEl.style.top = "-5px";
+            })
+            .then(await(function(){return callCounter == 3;}, 500))
+            .then(done);
+        });
+
+        it("reports at multiple thresholds", function(done) {
+            rootEl.appendChild(childEl);
+            document.body.appendChild(rootEl);
+
+            var callCounter = 0;
+            io = new IntersectionObserver(
+                function(records) {
+                    switch(callCounter) {
+                    case 0:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be(1);
+                    break;
+                    case 1:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
+                      // expect(records[0].intersectionRatio).to.be.greaterThan(0.25);
+                    break;
+                    case 2:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be.lessThan(0.25);
+                    break;
+                    case 3:
+                      expect(records.length).to.be(1);
+                      // expect(records[0].intersectionRatio).to.be(0.25);
+                    break;
+                    default:
+                      throw new Error("Too many calls");
+                    }
+                    callCounter++;
+                },
+                {root: rootEl, threshold: [0.5, 0.25]}
+            );
+
+            io.observe(childEl);
+
+            promiseAnimationFrame()
+            .then(await(function(){return callCounter == 1;}, 500))
+            .then(function() {
+                childEl.style.top = "-11px";
+            })
+            .then(await(function(){return callCounter == 2;}, 500))
+            .then(function() {
+                childEl.style.top = "-16px";
+            })
+            .then(await(function(){return callCounter == 3;}, 500))
+            .then(function() {
+                childEl.style.top = "-17px";
+            })
+            .then(promiseAnimationFrame)
+            .then(function() {
+                expect(io.takeRecords().length).to.be(0);
+                expect(callCounter).to.be(3);
+                childEl.style.top = "-15px";
+            })
+            .then(await(function(){return callCounter == 4;}, 500))
+            .then(done);
+        });
+
+        it("supports margins", function(done) {
+            rootEl.appendChild(childEl);
+            document.body.appendChild(rootEl);
+
+            var callCounter = 0;
+            io = new IntersectionObserver(
+                function(records) {
+                    if(callCounter <= 4) {
+                      expect(records.length).to.be(1);
+                    } else {
+                      throw new Error("Too many calls");
+                    }
+                    callCounter++;
+                },
+                {root: rootEl, threshold: [0.5, 0.25]}
+            );
+
+            io.observe(childEl);
+
+            childEl.style.top = "-25px";
+            promiseAnimationFrame()
+            .then(await(function(){return callCounter == 0;}, 500))
+            .then(function() {
+              childEl.style.top = "-10px";
+            })
+            .then(await(function(){return callCounter == 1;}, 500))
+            .then(function() {
+              childEl.style.top = "90px";
+            })
+            .then(await(function(){return callCounter == 1;}, 500))
+            .then(function() {
+              childEl.style.top = "96px";
+            })
+            .then(await(function(){return callCounter == 2;}, 500))
+            .then(function() {
+              childEl.style.top = "0px";
+              childEl.style.left = "-35px";
+            })
+            .then(await(function(){return callCounter == 2;}, 500))
+            .then(function() {
+              childEl.style.left = "-15px";
+            })
+            .then(await(function(){return callCounter == 3;}, 500))
+            .then(function() {
+              childEl.style.left = "-10px";
+            })
+            .then(await(function(){return callCounter == 4;}, 500))
+            .then(function() {
+              childEl.style.left = "110px";
+            })
+            .then(await(function(){return callCounter == 4;}, 500))
+            .then(done);
+        });
+        mocha.run();
+     </script>
+</body>
+</html>

--- a/polyfill/intersectionobserver_test.html
+++ b/polyfill/intersectionobserver_test.html
@@ -1,253 +1,253 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <style>
-    root {
+  <meta charset="utf-8">
+  <style>
+  root {
     background-color: pink;
     display: block;
-    }
-    child {
+  }
+  child {
     background-color: salmon;
     display: block;
-    }
-    </style>
+  }
+  </style>
 </head>
 <body>
-<script src="intersectionobserver-polyfill.js"></script>
-<div id="container" style="position: relative"></div>
-<div id="logger" style="white-space: pre-wrap"></div>
-    <div id="mocha"></div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/2.4.5/mocha.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.min.js"></script>
-    <script>mocha.setup('bdd')</script>
-    <script>
-        function promiseAnimationFrame() {
-            return new Promise(function(resolve) {
-                requestAnimationFrame(function() {
-                    resolve();
-                });
-            });
+  <script src="intersectionobserver-polyfill.js"></script>
+  <div id="container" style="position: relative"></div>
+  <div id="logger" style="white-space: pre-wrap"></div>
+  <div id="mocha"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mocha/2.4.5/mocha.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.min.js"></script>
+  <script>mocha.setup('bdd')</script>
+  <script>
+  function promiseAnimationFrame() {
+    return new Promise(function(resolve) {
+      requestAnimationFrame(function() {
+        resolve();
+      });
+    });
+  }
+
+  function await(f, timeout) {
+    var stack = new Error().stack;
+    return function() {
+      return new Promise(function(resolve) {
+        var timeoutId = setTimeout(function() {
+          throw new Error("Timed out " + stack);
+        }, timeout);
+        intervalId = setInterval(function() {
+          if(f()) {
+            clearInterval(intervalId);
+            clearTimeout(timeoutId);
+            resolve();
+          }
+        }, 50);
+      });
+    };
+  }
+
+  var rootEl, childEl, io;
+
+  beforeEach(function() {
+    io = null;
+    rootEl = document.createElement('div');
+    rootEl.setAttribute('style', 'display:block; position: relative; width: 200px; height: 100px; overflow: auto; background: #bbb');
+    childEl = document.createElement('div');
+    childEl.setAttribute('style', 'display:block; position: absolute; width: 20px; height: 20px; background: #f00');
+  });
+
+  afterEach(function() {
+    if (io && 'disconnect' in io) io.disconnect();
+    if (childEl.parentNode) childEl.parentNode.removeChild(childEl);
+    if (rootEl.parentNode) rootEl.parentNode.removeChild(rootEl);
+  });
+
+  it("triggers if elements already intersect when observing begins", function(done) {
+    rootEl.appendChild(childEl);
+    document.body.appendChild(rootEl);
+
+    io = new IntersectionObserver(
+      function(records) {
+        expect(records.length).to.be(1);
+        // expect(records[0].intersectionRatio).to.be(1);
+        done();
+      },
+      {root: rootEl}
+    );
+
+    io.observe(childEl);
+  });
+
+  it("reports at threshold correctly", function(done) {
+    rootEl.appendChild(childEl);
+    document.body.appendChild(rootEl);
+
+    var callCounter = 0;
+    io = new IntersectionObserver(
+      function(records) {
+        switch(callCounter) {
+          case 0:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be(1);
+          break;
+          case 1:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
+          break;
+          case 2:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be(0.5);
+          break;
+          default:
+          throw new Error("Too many calls");
         }
+        callCounter++;
+      },
+      {root: rootEl, threshold: 0.5}
+    );
 
-        function await(f, timeout) {
-          var stack = new Error().stack;
-          return function() {
-            return new Promise(function(resolve) {
-              var timeoutId = setTimeout(function() {
-                throw new Error("Timed out " + stack);
-              }, timeout);
-              intervalId = setInterval(function() {
-                if(f()) {
-                  clearInterval(intervalId);
-                  clearTimeout(timeoutId);
-                  resolve();
-                }
-              }, 50);
-            });
-          };
+    io.observe(childEl);
+
+    promiseAnimationFrame()
+    .then(await(function(){return callCounter == 1;}, 500))
+    .then(function() {
+      childEl.style.top = "-11px";
+    })
+    .then(await(function(){return callCounter == 2;}, 500))
+    .then(function() {
+      childEl.style.top = "-16px";
+    })
+    .then(promiseAnimationFrame)
+    .then(function() {
+      expect(io.takeRecords().length).to.be(0);
+      expect(callCounter).to.be(2);
+      childEl.style.top = "-5px";
+    })
+    .then(await(function(){return callCounter == 3;}, 500))
+    .then(done);
+  });
+
+  it("reports at multiple thresholds", function(done) {
+    rootEl.appendChild(childEl);
+    document.body.appendChild(rootEl);
+
+    var callCounter = 0;
+    io = new IntersectionObserver(
+      function(records) {
+        switch(callCounter) {
+          case 0:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be(1);
+          break;
+          case 1:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
+          // expect(records[0].intersectionRatio).to.be.greaterThan(0.25);
+          break;
+          case 2:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be.lessThan(0.25);
+          break;
+          case 3:
+          expect(records.length).to.be(1);
+          // expect(records[0].intersectionRatio).to.be(0.25);
+          break;
+          default:
+          throw new Error("Too many calls");
         }
+        callCounter++;
+      },
+      {root: rootEl, threshold: [0.5, 0.25]}
+    );
 
-        var rootEl, childEl, io;
+    io.observe(childEl);
 
-        beforeEach(function() {
-            io = null;
-            rootEl = document.createElement('div');
-            rootEl.setAttribute('style', 'display:block; position: relative; width: 200px; height: 100px; overflow: auto; background: #bbb');
-            childEl = document.createElement('div');
-            childEl.setAttribute('style', 'display:block; position: absolute; width: 20px; height: 20px; background: #f00');
-        });
+    promiseAnimationFrame()
+    .then(await(function(){return callCounter == 1;}, 500))
+    .then(function() {
+      childEl.style.top = "-11px";
+    })
+    .then(await(function(){return callCounter == 2;}, 500))
+    .then(function() {
+      childEl.style.top = "-16px";
+    })
+    .then(await(function(){return callCounter == 3;}, 500))
+    .then(function() {
+      childEl.style.top = "-17px";
+    })
+    .then(promiseAnimationFrame)
+    .then(function() {
+      expect(io.takeRecords().length).to.be(0);
+      expect(callCounter).to.be(3);
+      childEl.style.top = "-15px";
+    })
+    .then(await(function(){return callCounter == 4;}, 500))
+    .then(done);
+  });
 
-        afterEach(function() {
-            if (io && 'disconnect' in io) io.disconnect();
-            if (childEl.parentNode) childEl.parentNode.removeChild(childEl);
-            if (rootEl.parentNode) rootEl.parentNode.removeChild(rootEl);
-        });
+  it("supports margins", function(done) {
+    rootEl.appendChild(childEl);
+    document.body.appendChild(rootEl);
 
-        it("triggers if elements already intersect when observing begins", function(done) {
-            rootEl.appendChild(childEl);
-            document.body.appendChild(rootEl);
+    var callCounter = 0;
+    io = new IntersectionObserver(
+      function(records) {
+        if(callCounter <= 6) {
+          expect(records.length).to.be(1);
+        } else {
+          throw new Error("Too many calls");
+        }
+        callCounter++;
+      },
+      {root: rootEl, margin: "5px 10% 10% 15px"}
+    );
 
-            io = new IntersectionObserver(
-                function(records) {
-                    expect(records.length).to.be(1);
-                    // expect(records[0].intersectionRatio).to.be(1);
-                    done();
-                },
-                {root: rootEl}
-            );
+    io.observe(childEl);
 
-            io.observe(childEl);
-        });
-
-        it("reports at threshold correctly", function(done) {
-            rootEl.appendChild(childEl);
-            document.body.appendChild(rootEl);
-
-            var callCounter = 0;
-            io = new IntersectionObserver(
-                function(records) {
-                    switch(callCounter) {
-                    case 0:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be(1);
-                    break;
-                    case 1:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
-                    break;
-                    case 2:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be(0.5);
-                    break;
-                    default:
-                      throw new Error("Too many calls");
-                    }
-                    callCounter++;
-                },
-                {root: rootEl, threshold: 0.5}
-            );
-
-            io.observe(childEl);
-
-            promiseAnimationFrame()
-            .then(await(function(){return callCounter == 1;}, 500))
-            .then(function() {
-                childEl.style.top = "-11px";
-            })
-            .then(await(function(){return callCounter == 2;}, 500))
-            .then(function() {
-                childEl.style.top = "-16px";
-            })
-            .then(promiseAnimationFrame)
-            .then(function() {
-                expect(io.takeRecords().length).to.be(0);
-                expect(callCounter).to.be(2);
-                childEl.style.top = "-5px";
-            })
-            .then(await(function(){return callCounter == 3;}, 500))
-            .then(done);
-        });
-
-        it("reports at multiple thresholds", function(done) {
-            rootEl.appendChild(childEl);
-            document.body.appendChild(rootEl);
-
-            var callCounter = 0;
-            io = new IntersectionObserver(
-                function(records) {
-                    switch(callCounter) {
-                    case 0:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be(1);
-                    break;
-                    case 1:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be.lessThan(0.5);
-                      // expect(records[0].intersectionRatio).to.be.greaterThan(0.25);
-                    break;
-                    case 2:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be.lessThan(0.25);
-                    break;
-                    case 3:
-                      expect(records.length).to.be(1);
-                      // expect(records[0].intersectionRatio).to.be(0.25);
-                    break;
-                    default:
-                      throw new Error("Too many calls");
-                    }
-                    callCounter++;
-                },
-                {root: rootEl, threshold: [0.5, 0.25]}
-            );
-
-            io.observe(childEl);
-
-            promiseAnimationFrame()
-            .then(await(function(){return callCounter == 1;}, 500))
-            .then(function() {
-                childEl.style.top = "-11px";
-            })
-            .then(await(function(){return callCounter == 2;}, 500))
-            .then(function() {
-                childEl.style.top = "-16px";
-            })
-            .then(await(function(){return callCounter == 3;}, 500))
-            .then(function() {
-                childEl.style.top = "-17px";
-            })
-            .then(promiseAnimationFrame)
-            .then(function() {
-                expect(io.takeRecords().length).to.be(0);
-                expect(callCounter).to.be(3);
-                childEl.style.top = "-15px";
-            })
-            .then(await(function(){return callCounter == 4;}, 500))
-            .then(done);
-        });
-
-        it("supports margins", function(done) {
-            rootEl.appendChild(childEl);
-            document.body.appendChild(rootEl);
-
-            var callCounter = 0;
-            io = new IntersectionObserver(
-                  function(records) {
-                    if(callCounter <= 6) {
-                      expect(records.length).to.be(1);
-                    } else {
-                      throw new Error("Too many calls");
-                    }
-                    callCounter++;
-                  },
-                {root: rootEl, margin: "5px 10% 10% 15px"}
-            );
-
-            io.observe(childEl);
-
-            childEl.style.top = "-15px";
-            promiseAnimationFrame()
-            .then(await(function(){return callCounter == 1;}, 500))
-            .then(function() {
-              childEl.style.top = "-14px";
-            })
-            .then(await(function(){return callCounter == 2;}, 500))
-            .then(function() {
-              childEl.style.top = "86px";
-            })
-            .then(await(function(){return callCounter == 3;}, 500))
-            .then(function() {
-              childEl.style.top = "87px";
-            })
-            .then(promiseAnimationFrame)
-            .then(await(function(){return callCounter == 3;}, 500))
-            .then(function() {
-              childEl.style.top = "0px";
-              childEl.style.left = "0px";
-            })
-            .then(await(function(){return callCounter == 4;}, 500))
-            .then(function() {
-              childEl.style.left = "-1px";
-            })
-            .then(promiseAnimationFrame)
-            .then(await(function(){return callCounter == 4;}, 500))
-            .then(function() {
-              childEl.style.left = "1px";
-            })
-            .then(await(function(){return callCounter == 5;}, 500))
-            .then(function() {
-              childEl.style.left = "180px";
-            })
-            .then(await(function(){return callCounter == 6;}, 500))
-            .then(function() {
-              childEl.style.left = "181px";
-            })
-            .then(promiseAnimationFrame)
-            .then(await(function(){return callCounter == 6;}, 500))
-            .then(done);
-        });
-        mocha.run();
-     </script>
+    childEl.style.top = "-15px";
+    promiseAnimationFrame()
+    .then(await(function(){return callCounter == 1;}, 500))
+    .then(function() {
+      childEl.style.top = "-14px";
+    })
+    .then(await(function(){return callCounter == 2;}, 500))
+    .then(function() {
+      childEl.style.top = "86px";
+    })
+    .then(await(function(){return callCounter == 3;}, 500))
+    .then(function() {
+      childEl.style.top = "87px";
+    })
+    .then(promiseAnimationFrame)
+    .then(await(function(){return callCounter == 3;}, 500))
+    .then(function() {
+      childEl.style.top = "0px";
+      childEl.style.left = "0px";
+    })
+    .then(await(function(){return callCounter == 4;}, 500))
+    .then(function() {
+      childEl.style.left = "-1px";
+    })
+    .then(promiseAnimationFrame)
+    .then(await(function(){return callCounter == 4;}, 500))
+    .then(function() {
+      childEl.style.left = "1px";
+    })
+    .then(await(function(){return callCounter == 5;}, 500))
+    .then(function() {
+      childEl.style.left = "180px";
+    })
+    .then(await(function(){return callCounter == 6;}, 500))
+    .then(function() {
+      childEl.style.left = "181px";
+    })
+    .then(promiseAnimationFrame)
+    .then(await(function(){return callCounter == 6;}, 500))
+    .then(done);
+  });
+  mocha.run();
+  </script>
 </body>
 </html>

--- a/polyfill/intersectionobserver_test.html
+++ b/polyfill/intersectionobserver_test.html
@@ -149,7 +149,7 @@ test(()=>{
   child.style.top = "-20px";
 
   io.observe(child);
-  
+
   var records = io.takeRecords();
   io.disconnect();
   return assert(records.length === 1 && records[0].intersectionRatio === 0);
@@ -191,7 +191,7 @@ test(()=>{
 
   child.style.top = "-10px";
   var records = io.takeRecords();
-  output.push(assert(records.length == 0));
+  output.push(assert(records.length == 1 && records[0].intersectionRatio === 0.5));
 
   io.disconnect();
   return output.join('\n');
@@ -230,7 +230,7 @@ test(()=>{
   child.style.top = "-11px";
   var records = io.takeRecords();
   output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.5 && records[0].intersectionRatio >= 0.25));
-  
+
   child.style.top = "-16px";
   var records = io.takeRecords();
   output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.25));
@@ -238,11 +238,11 @@ test(()=>{
   child.style.top = "-17px";
   var records = io.takeRecords();
   output.push(assert(records.length == 0));
-  
+
   child.style.top = "-15px";
   var records = io.takeRecords();
-  output.push(assert(records.length == 0));
-  
+  output.push(assert(records.length == 1 && records[0].intersectionRatio === 0.25));
+
   io.disconnect();
   return output.join('\n');
 }, 'multiple thresholds')

--- a/polyfill/intersectionobserver_test.html
+++ b/polyfill/intersectionobserver_test.html
@@ -25,7 +25,7 @@
         function promiseAnimationFrame() {
             return new Promise(function(resolve) {
                 requestAnimationFrame(function() {
-                   resolve();
+                    resolve();
                 });
             });
         }
@@ -193,51 +193,58 @@
 
             var callCounter = 0;
             io = new IntersectionObserver(
-                function(records) {
-                    if(callCounter <= 4) {
+                  function(records) {
+                    if(callCounter <= 6) {
                       expect(records.length).to.be(1);
                     } else {
                       throw new Error("Too many calls");
                     }
                     callCounter++;
-                },
-                {root: rootEl, threshold: [0.5, 0.25]}
+                  },
+                {root: rootEl, margin: "5px 10% 10% 15px"}
             );
 
             io.observe(childEl);
 
-            childEl.style.top = "-25px";
+            childEl.style.top = "-15px";
             promiseAnimationFrame()
-            .then(await(function(){return callCounter == 0;}, 500))
-            .then(function() {
-              childEl.style.top = "-10px";
-            })
             .then(await(function(){return callCounter == 1;}, 500))
             .then(function() {
-              childEl.style.top = "90px";
-            })
-            .then(await(function(){return callCounter == 1;}, 500))
-            .then(function() {
-              childEl.style.top = "96px";
+              childEl.style.top = "-14px";
             })
             .then(await(function(){return callCounter == 2;}, 500))
             .then(function() {
-              childEl.style.top = "0px";
-              childEl.style.left = "-35px";
-            })
-            .then(await(function(){return callCounter == 2;}, 500))
-            .then(function() {
-              childEl.style.left = "-15px";
+              childEl.style.top = "86px";
             })
             .then(await(function(){return callCounter == 3;}, 500))
             .then(function() {
-              childEl.style.left = "-10px";
+              childEl.style.top = "87px";
+            })
+            .then(promiseAnimationFrame)
+            .then(await(function(){return callCounter == 3;}, 500))
+            .then(function() {
+              childEl.style.top = "0px";
+              childEl.style.left = "0px";
             })
             .then(await(function(){return callCounter == 4;}, 500))
             .then(function() {
-              childEl.style.left = "110px";
+              childEl.style.left = "-1px";
             })
+            .then(promiseAnimationFrame)
             .then(await(function(){return callCounter == 4;}, 500))
+            .then(function() {
+              childEl.style.left = "1px";
+            })
+            .then(await(function(){return callCounter == 5;}, 500))
+            .then(function() {
+              childEl.style.left = "180px";
+            })
+            .then(await(function(){return callCounter == 6;}, 500))
+            .then(function() {
+              childEl.style.left = "181px";
+            })
+            .then(promiseAnimationFrame)
+            .then(await(function(){return callCounter == 6;}, 500))
             .then(done);
         });
         mocha.run();

--- a/polyfill/intersectionobserver_test.html
+++ b/polyfill/intersectionobserver_test.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<script src="intersectionobserver-polyfill.js"></script>
+<style>
+root {
+  background-color: pink;
+  display: block;
+}
+child {
+  background-color: salmon;
+  display: block;
+}
+</style>
+<div id="container" style="position: relative"></div>
+<div id="logger" style="white-space: pre-wrap"></div>
+<script>
+var testIndex = 0;
+
+function test(callback, title) {
+  if(!title) {
+    title = '';
+  }
+  document.getElementById('container').innerHTML = '';
+  document.getElementById('logger').innerHTML += 'Test ' + title + ' ' + (++testIndex) + ': ' + callback() + '\n\n';
+}
+
+function assert(a) {
+  if (a) {
+    return 'Passed';
+  }
+  return '<b>Failed</b>';
+}
+
+test(()=>{
+  return assert(true);
+}, 'the testing framework')
+
+// Observing root not in the DOM.
+test(()=>{
+  var root = document.createElement('div');
+  var io = new IntersectionObserver(function(){},{
+    root: root,
+  });
+
+  var didThrow = false;
+  try {
+    io.observe(document.getElementById('container'));
+  } catch (e) {
+    didThrow = true;
+  }
+
+  io.disconnect();
+  return assert(didThrow);
+}, 'Observing root not in the DOM')
+
+// Observing unrooted element.
+test(()=>{
+  var io = new IntersectionObserver(function(){}, {});
+
+  var didThrow = false;
+  try {
+    io.observe(document.createElement('container'));
+  } catch (e) {
+    didThrow = true;
+  }
+
+  io.disconnect();
+  return assert(didThrow);
+}, 'Observing unrooted element')
+
+// Observing child of root.
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      root: root
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  var didThrow = false;
+  try {
+    io.observe(child);
+  } catch (e) {
+    didThrow = true;
+  }
+
+  io.disconnect();
+  return assert(!didThrow);
+}, 'Observing child of root')
+
+// takeRecords and observe already intersecting element.
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  root.style.height = "100px";
+  root.style.width = "100px";
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      root: root
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  child.style.height = "20px";
+  child.style.width = "20px";
+  child.style.position = "absolute";
+
+  io.observe(child);
+
+  var numRecords = io.takeRecords().length;
+  io.disconnect();
+  return assert(numRecords);
+}, 'takeRecords and observe already intersecting element')
+
+// Observe non-intersecting element.
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  root.style.height = "100px";
+  root.style.width = "100px";
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      root: root,
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  child.style.height = "20px";
+  child.style.width = "20px";
+  child.style.position = "absolute";
+  child.style.top = "-20px";
+
+  io.observe(child);
+  
+  var records = io.takeRecords();
+  io.disconnect();
+  return assert(records.length === 1 && records[0].intersectionRatio === 0);
+}, 'observe non-intersecting element')
+
+// thresholds
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  root.style.height = "100px";
+  root.style.width = "100px";
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      threshold: 0.5,
+      root: root,
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  child.style.height = "20px";
+  child.style.width = "20px";
+  child.style.position = "absolute";
+
+  io.observe(child);
+
+  var output = []
+  var records = io.takeRecords();
+  output.push(assert(records.length == 1 && records[0].intersectionRatio === 1));
+
+  child.style.top = "-11px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.5));
+
+  child.style.top = "-10px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 0));
+
+  io.disconnect();
+  return output.join('\n');
+}, 'thresholds')
+
+// multiple thresholds
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  root.style.height = "100px";
+  root.style.width = "100px";
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      threshold: [0.5, 0.25],
+      root: root,
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  child.style.height = "20px";
+  child.style.width = "20px";
+  child.style.position = "absolute";
+
+  io.observe(child);
+
+  var output = []
+  var records = io.takeRecords();
+  output.push(assert(records.length == 1 && records[0].intersectionRatio === 1));
+
+  child.style.top = "-11px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.5 && records[0].intersectionRatio >= 0.25));
+  
+  child.style.top = "-16px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 1 && records[0].intersectionRatio <= 0.25));
+
+  child.style.top = "-17px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 0));
+  
+  child.style.top = "-15px";
+  var records = io.takeRecords();
+  output.push(assert(records.length == 0));
+  
+  io.disconnect();
+  return output.join('\n');
+}, 'multiple thresholds')
+
+// margins
+test(()=>{
+  var container = document.getElementById('container');
+  var root = document.createElement('root');
+  container.appendChild(root);
+
+  root.style.height = "100px";
+  root.style.width = "200px";
+
+  var io = new IntersectionObserver(
+    ()=>{ console.log("This shouldn't be called since we always takeRecords."); },
+    {
+      margin: "5px 10% 10% 15px",
+      root: root,
+    }
+  );
+
+  var child = document.createElement('child');
+  root.appendChild(child);
+
+  child.style.height = "20px";
+  child.style.width = "20px";
+  child.style.position = "absolute";
+
+  io.observe(child);
+
+  var output = []
+  output.push(assert(io.takeRecords().length));
+
+  // Stop intersecting from the top.
+  child.style.top = "-25px";
+  output.push(assert(io.takeRecords().length));
+
+  // Start intersecting from the top.
+  child.style.top = "-24px";
+  output.push(assert(io.takeRecords().length));
+
+  // Stop intersecting from the bottom.
+  child.style.top = "110px";
+  output.push(assert(io.takeRecords().length));
+
+  // Start intersecting from the bottom.
+  child.style.top = "109px";
+  output.push(assert(io.takeRecords().length));
+
+  // Stop intersecting from the left.
+  child.style.left = "-35px";
+  output.push(assert(io.takeRecords().length));
+
+  // Start intersecting from the left.
+  child.style.left = "-34px";
+  output.push(assert(io.takeRecords().length));
+
+  // Stop intersecting from the right.
+  child.style.left = "220px";
+  output.push(assert(io.takeRecords().length));
+
+  // Start intersecting from the right.
+  child.style.left = "219px";
+  output.push(assert(io.takeRecords().length));
+
+  io.disconnect();
+  return output.join('\n');
+}, 'margins')
+
+</script>


### PR DESCRIPTION
r: @ojanvafai 
cc: @ianvollick @paullewis @flackr

This adds a polyfill for the IntersectionObserver API. It is compatible to the current version of the spec but ignores margins for now, as I wanted to avoid implementing a CSS string parser.

There’s also a simple test suite by @ojanvafai. All tests pass except for the margin tests for the reasons mentioned above. Please take a look at the tests to check that the polyfill is behaving as you’d expect.
![screenshot 2016-03-16 14 05 35](https://cloud.githubusercontent.com/assets/234957/13814970/9537797a-eb80-11e5-8356-627bf13b55be.png)

Any other feedback obviously welcome as well :)
