### PR TITLE
Fix explainer code example

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -218,13 +218,14 @@ function query(selector) {
   return Array.prototype.slice.apply(document.querySelectorAll(selector));
 }
 
-var observer = new IntersectionObserver({
+var observer = new IntersectionObserver(
   // Pre-load items that are within 2 multiples of the visible viewport height.
   function(changes) {
     changes.forEach(function(change) {
+      var container = change.target;
       var content = container.querySelector("template").content;
       container.appendChild(content);
-      observer.unobserve(change.element);
+      observer.unobserve(container);
     });
   },
   { rootMargin: "200% 0" }


### PR DESCRIPTION
Incorrectly used undefined `element` property (out of date?), undefined variable and syntax error (stray `{`).