### PR TITLE
Use native stuff 

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -186,7 +186,7 @@ IntersectionObserver.prototype.takeRecords = function() {
  */
 IntersectionObserver.prototype._initThresholds = function(opt_threshold) {
   var threshold = opt_threshold || [0];
-  if (!isArray(threshold)) threshold = [threshold];
+  if (!Array.isArray(threshold)) threshold = [threshold];
 
   return threshold.sort().filter(function(t, i, a) {
     if (typeof t != 'number' || isNaN(t) || t < 0 || t > 1) {
@@ -656,16 +656,6 @@ function getEmptyRect() {
     width: 0,
     height: 0
   };
-}
-
-
-/**
- * Determins if a value is a JavaScript array.
- * @param {*} value Any JavaScript value.
- * @return {boolean} True if the passed value is an array.
- */
-function isArray(value) {
-  return Object.prototype.toString.call(value) == '[object Array]';
 }
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -15,6 +15,7 @@
  */
 
 (function(window, document) {
+'use strict';
 
 
 // Exits early if all IntersectionObserver and IntersectionObserverEntry

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -473,7 +473,7 @@ IntersectionObserver.prototype._hasCrossedThreshold =
  * @private
  */
 IntersectionObserver.prototype._rootIsInDom = function() {
-  return !this.root || contains(document, this.root);
+  return !this.root || document.contains(this.root);
 };
 
 
@@ -484,7 +484,7 @@ IntersectionObserver.prototype._rootIsInDom = function() {
  * @private
  */
 IntersectionObserver.prototype._rootContainsTarget = function(target) {
-  return contains(this.root || document, target);
+  return (this.root || document).contains(target);
 };
 
 
@@ -656,21 +656,6 @@ function getEmptyRect() {
     width: 0,
     height: 0
   };
-}
-
-
-/**
- * Determines if a root elements contains a target element as a descendant.
- * @param {Element} root The root element.
- * @param {Element} target The target to check.
- * @return {boolean} True if the target is a descendant of root.
- */
-function contains(root, target) {
-  var parent = target.parentNode;
-  while (parent) {
-    if (root == parent) return true;
-    parent = parent.parentNode;
-  }
 }
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -324,7 +324,7 @@ IntersectionObserver.prototype._checkForIntersections = function() {
         this._queuedEntries.push(newEntry);
       }
     }
-  }.bind(this));
+  }, this);
 
   if (this._queuedEntries.length) {
     this._callback(this.takeRecords(), this);
@@ -508,7 +508,7 @@ IntersectionObserver.prototype._registerInstance = function() {
 IntersectionObserver.prototype._unregisterInstance = function() {
   registry = registry.filter(function(instance) {
     return instance !== this;
-  }.bind(this));
+  }, this);
 };
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -506,9 +506,8 @@ IntersectionObserver.prototype._registerInstance = function() {
  * @private
  */
 IntersectionObserver.prototype._unregisterInstance = function() {
-  registry = registry.filter(function(instance) {
-    return instance !== this;
-  }, this);
+  var index = registry.indexOf(this);
+  if (index != -1) registry.splice(index, 1);
 };
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -27,6 +27,11 @@ if ('IntersectionObserver' in window &&
 }
 
 
+// Use :root element of the document for .contains() calls because older IEs
+// support Node.prototype.contains only on Element nodes.
+var docElement = document.documentElement;
+
+
 /**
  * An IntersectionObserver registry. This registry exists to hold a strong
  * reference to IntersectionObserver instances currently observering a target
@@ -474,7 +479,7 @@ IntersectionObserver.prototype._hasCrossedThreshold =
  * @private
  */
 IntersectionObserver.prototype._rootIsInDom = function() {
-  return !this.root || document.contains(this.root);
+  return !this.root || docElement.contains(this.root);
 };
 
 
@@ -485,7 +490,7 @@ IntersectionObserver.prototype._rootIsInDom = function() {
  * @private
  */
 IntersectionObserver.prototype._rootContainsTarget = function(target) {
-  return (this.root || document).contains(target);
+  return (this.root || docElement).contains(target);
 };
 
 


### PR DESCRIPTION
1. `Node.prototype.contains` is available since IE5: replace custom helper with it.
2. `Array.isArray` should be available, because `es5shim` is required.
3. `use strict` is cool (explicit error stuff), and without it crankshaft will bailout on parameter reassignment.
4. They say `bind` is slow, lets pass `this` to es5 array methods as last argument.
5. Replace `filter` with `indexOf` + `splice`, should be faster & safer than reassignment.