### PR TITLE
zero-size targets should have intersectionRatio 1 according to spec

### DIFF
--- a/polyfill/intersection-observer-test.js
+++ b/polyfill/intersection-observer-test.js
@@ -553,7 +553,7 @@ describe('IntersectionObserver', function() {
 
       io = new IntersectionObserver(function(records) {
         expect(records.length).to.be(1);
-        expect(records[0].intersectionRatio).to.be(0);
+        expect(records[0].intersectionRatio).to.be(1);
         done();
       }, {root: rootEl});
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -55,12 +55,12 @@ function IntersectionObserverEntry(entry) {
   this.intersectionRect = entry.intersectionRect || getEmptyRect();
   this.isIntersecting = !!entry.intersectionRect;
 
-  // Calculates the intersection ratio. Sets it to 0 if the target area is 0.
+  // Calculates the intersection ratio. Sets it to 1 if the target area is 0.
   var targetRect = this.boundingClientRect;
   var targetArea = targetRect.width * targetRect.height;
   var intersectionRect = this.intersectionRect;
   var intersectionArea = intersectionRect.width * intersectionRect.height;
-  this.intersectionRatio = targetArea ? (intersectionArea / targetArea) : 0;
+  this.intersectionRatio = targetArea ? (intersectionArea / targetArea) : 1;
 }
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -55,12 +55,19 @@ function IntersectionObserverEntry(entry) {
   this.intersectionRect = entry.intersectionRect || getEmptyRect();
   this.isIntersecting = !!entry.intersectionRect;
 
-  // Calculates the intersection ratio. Sets it to 1 if the target area is 0.
+  // Calculates the intersection ratio
   var targetRect = this.boundingClientRect;
   var targetArea = targetRect.width * targetRect.height;
   var intersectionRect = this.intersectionRect;
   var intersectionArea = intersectionRect.width * intersectionRect.height;
-  this.intersectionRatio = targetArea ? (intersectionArea / targetArea) : 1;
+
+  // Sets intersection ratio.
+  if (targetArea) {
+    this.intersectionRatio = intersectionArea / targetArea;
+  } else {
+    // If area is zero and is intersecting, sets to 1, otherwise to 0
+    this.intersectionRatio = this.isIntersecting ? 1 : 0;
+  }
 }
 
 

--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -55,7 +55,7 @@ function IntersectionObserverEntry(entry) {
   this.intersectionRect = entry.intersectionRect || getEmptyRect();
   this.isIntersecting = !!entry.intersectionRect;
 
-  // Calculates the intersection ratio
+  // Calculates the intersection ratio.
   var targetRect = this.boundingClientRect;
   var targetArea = targetRect.width * targetRect.height;
   var intersectionRect = this.intersectionRect;


### PR DESCRIPTION
as stated on https://github.com/WICG/IntersectionObserver/issues/190 and https://wicg.github.io/IntersectionObserver/#dom-intersectionobserverentry-intersectionratio

*If the boundingClientRect has non-zero area, this will be the ratio of intersectionRect area to boundingClientRect area. **Otherwise, this will be 1 if the isIntersecting is true, and 0 if not.***

Note: I already applied to join the group

