### PR TITLE
getBoundingClientRect should always return a rect

### DIFF
--- a/polyfill/intersection-observer.js
+++ b/polyfill/intersection-observer.js
@@ -623,8 +623,15 @@ function computeRectIntersection(rect1, rect2) {
  * @return {Object} The (possibly shimmed) rect of the element.
  */
 function getBoundingClientRect(el) {
-  var rect = el.getBoundingClientRect();
-  if (!rect) return;
+  var rect;
+
+  try {
+      rect = el.getBoundingClientRect();
+  } catch (e) {/* ignore Windows 7 IE11 "Unspecified error" */}
+
+  if (!rect) {
+      return getEmptyRect();
+  }
 
   // Older IE
   if (!rect.width || !rect.height) {


### PR DESCRIPTION
I'm running into issues with my projects tests running on IE11 in Windows 7.

IE11 throws an "Unspecified error." at the line that calls `getBoundingClientRect`. Catching the exception prevents the error from breaking our tests. Returning an empty rect prevents the polyfill from creating an entry with a `boundingClientRect` of `undefined` which would throw in `_checkForIntersections`.

This makes the polyfill work to spec in IE11 by working around this issue https://connect.microsoft.com/IE/feedback/details/829392/calling-getboundingclientrect-on-an-html-element-that-has-not-been-added-to-the-dom-causes-unspecified-error