### PR TITLE
fix rootMargin value for Firefox

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -209,7 +209,7 @@ var observer = new IntersectionObserver(
       observer.unobserve(container);
     });
   },
-  { rootMargin: "200% 0" }
+  { rootMargin: "200% 0%" }
 );
 
 // Set up lazy loading


### PR DESCRIPTION
Hi,

Firefox ESR 52.2.0 gave a helpful error message in console about malformed `rootMargin` value when using this polyfill.

With this fix error message goes away and polyfill is working smoothly :)

Have a nice weekend
midzer